### PR TITLE
token: pass the project id to get the catalog

### DIFF
--- a/lib/ex_swift/auth/token.ex
+++ b/lib/ex_swift/auth/token.ex
@@ -32,6 +32,11 @@ defmodule ExSwift.Auth.Token do
               password: config.password
             }
           }
+        },
+        scope: %{
+          project: %{
+            id: config.project_id
+          }
         }
       }
     }

--- a/lib/ex_swift/config.ex
+++ b/lib/ex_swift/config.ex
@@ -5,6 +5,7 @@ defmodule ExSwift.Config do
     field :auth_url, String.t(), enforce: true
     field :username, String.t(), enforce: true
     field :password, String.t(), enforce: true
+    field :project_id, String.t(), enforce: true
     field :token, ExSwift.Auth.Token.t()
 
     field :service_type, String.t(), default: "object-store"


### PR DESCRIPTION
Keystone returns the service catalog only with the scoped token. If the
user has no default project and we don't pass a project_id, we end up
in the case where the token is unscoped.

By passing the project id, we ensure the token is scoped.

Note, the behaviour is not recent, it was already the case OpenStack
Havana. From the changelog:

    A token without an explicit scope of authorization is issued if the user
    does not specify a project and does not have authorization on the project
    specified by their default project attribute

See: https://docs.openstack.org/api-ref/identity/v3/#service-catalog-and-endpoints
